### PR TITLE
(Refact) PostWritePage 로컬내의 전역 변수와 타입 외부로 분리 (#17)

### DIFF
--- a/src/components/common/post/Category.ts
+++ b/src/components/common/post/Category.ts
@@ -1,0 +1,41 @@
+// post 에서 사용중인 공용 컴포넌트와 타입 정의
+// category 관련 상수, 댓글 조언 타입정의
+
+
+// 공용으로 사용하기 위한 카테고리 상수
+// 공용 문자열 정규화
+export const normalizeLabel = (str: string): string => {
+  return str.trim().toLowerCase();
+}; // 굳이 안해도 될것같긴한데..
+
+// 카테고리 목록 , 필요시 여기만 수정
+export const Categories = [
+  "일상",
+  "연애",
+  "인간관계",
+  "주식/투자",
+  "학교생활",
+  "진로",
+  "창업",
+  "대입/입시",
+  "취업/자격증",
+  "결혼",
+  "여행",
+  "부동산",
+  "정신 건강",
+  "자유",
+] as const;
+
+export type CategoryName = (typeof Categories)[number];
+
+// id 매핑
+// 작성할때 넘겨주는 값이 number여서 각 배열 순서대로 번호 부여
+// CategoryIdMap.get("일상") => 1
+export const CategoryIdMap = new Map<string, number>(
+  Categories.map((category, index) => [category, index + 1])
+);
+
+export const getCategoryId = (category: string)=> CategoryIdMap.get(normalizeLabel(category));
+
+
+// topic id도 추가할 예정

--- a/src/pages/Post/PostWritePage.tsx
+++ b/src/pages/Post/PostWritePage.tsx
@@ -1,4 +1,11 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef} from "react";
+import {
+  Categories,
+  normalizeLabel,
+  CategoryIdMap,
+  type CategoryName,
+} from "../../components/common/post/Category";
+import { wantedCommentType, wantedCommentTypeMap } from "../../types/Common";
 import Plus from "../../assets/icons/Plus.svg?react";
 import BasicImage from "../../assets/icons/BasicImage.svg?react";
 import UpArrow from "../../assets/icons/UpArrow.svg?react";
@@ -77,43 +84,21 @@ const PostWrite = () => {
   }, []);
 
   // 4. 카테고리 목록선언 / 드롭다운 Ui 구현
-  // 선택된 카테고리, 드롭다운 상태관리와 정규화 선언
   /** 랜덤주제(topic도 들어가야하며 카테고리와 똑같이 id매핑 필요) */
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const normalize = (str: string) => str.trim().toLowerCase();
-
+ 
   // 드롭다운 ref
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // 카테고리 목록과 id매핑
-  const [categories] = useState<string[]>([
-    "일상",
-    "연애",
-    "인간관계",
-    "주식/투자",
-    "학교생활",
-    "진로",
-    "창업",
-    "대입/입시",
-    "취업/자격증",
-    "결혼",
-    "여행",
-    "부동산",
-    "정신 건강",
-    "자유",
-  ]);
-  const categoryMap = useMemo(() => {
-    const m = new Map<string, number>();
-    categories.forEach((name, idx) => {
-      m.set(normalize(name), idx + 1); // 1-based
-    });
-    return m;
-  }, [categories]);
-
-  const applySelection = (category: string) => {
+  // 카테고리 선택 적용 함수
+  const applySelection = (category: CategoryName) => {
     setSelectedCategory(category);
-    const id = categoryMap.get(normalize(category));
+    const id = CategoryIdMap.get(category);
+    // id가 없을리 없지만 혹시모르니 예외처리
+    if(!id) {
+      throw new Error("유효하지 않은 카테고리입니다.");
+    }
     console.log("선택된 카테고리:", category, "ID:", id);
   };
 
@@ -135,14 +120,13 @@ const PostWrite = () => {
   }, []);
 
   // 4-2 checkbox 상태관리
-  const [commentTypes, setCommentTypes] = useState<{
-    ADVICE: boolean;
-    EMPATHY: boolean;
-  }>({ ADVICE: true, EMPATHY: false });
+  const [commentTypes, setCommentTypes] = useState<wantedCommentTypeMap>({ ADVICE: true, EMPATHY: false });
 
-  const toggleCommentType = (type: "ADVICE" | "EMPATHY") => {
+  const toggleCommentType = (type: wantedCommentType) => {
     setCommentTypes((prev) => ({ ...prev, [type]: !prev[type] }));
   };
+
+  console.log("선택된 댓글 종류:", commentTypes);
 
   return (
     <div className="w-full flex flex-col gap-20">
@@ -282,10 +266,10 @@ const PostWrite = () => {
             {/* 드롭다운 리스트 */}
             {isDropdownOpen && (
               <ul className="absolute pt-5 top-12 right-[0.4px] bg-[#f3f3f3] w-full h-[180px] rounded-b-[1.25rem] overflow-y-scroll z-20 custom-scroll">
-                {categories.map((label, idx) => {
+                {Categories.map((label, idx) => {
                   const isSelected =
                     selectedCategory &&
-                    normalize(selectedCategory) === normalize(label);
+                    normalizeLabel(selectedCategory) === normalizeLabel(label);
                   return (
                     <li
                       key={`${label}-${idx}`}
@@ -295,7 +279,7 @@ const PostWrite = () => {
                       }}
                       className={`px-5 pb-7 cursor-pointer text-[1.125rem]
                   ${isSelected ? "text-black" : "text-[#999999]"}
-                  ${idx !== categories.length - 1 ? "" : ""}
+                  ${idx !== Categories.length - 1 ? "" : ""}
                 `}
                     >
                       {label}

--- a/src/types/Common.ts
+++ b/src/types/Common.ts
@@ -1,13 +1,20 @@
 export type CommonResponse<T> = {
-    isSuccess: boolean;
-    code: string;
-    message: string;
-    pageInfo?: {
-        page: number;
-        size: number;
-        hasNext: boolean;
-        totalElements: number;
-        totalPages: number;
-    };
-    result: T;
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  pageInfo?: {
+    page: number;
+    size: number;
+    hasNext: boolean;
+    totalElements: number;
+    totalPages: number;
+  };
+  result: T;
 };
+
+// check box에서 선택가능한 타입. (조언/공감)
+export type wantedCommentType = "ADVICE" | "EMPATHY";
+
+// postWritePage에서 사용되는 check box 상태 타입
+// 로컬에서는 ADVICE, EMPATHY 두가지 상태를 boolean으로 관리하기때문에 나중에 POST요청할때 굳이굳이 string 배열로 변환해야해서..
+export type wantedCommentTypeMap = Record<wantedCommentType, boolean>;


### PR DESCRIPTION
## 🛠️ 작업 내용
카테고리 목록과 이를 매핑하는 함수 외부로 분리
조언, 공감 체크박스 타입을 외부로 분리 -> 로컬내에서는 boolean 타입으로 사용되기에 로컬내에서 사용가능한 전역함수도 추가

## ✅ 체크리스트
- [ ] UI 구현
- [ ] API 연동
- [ ] 에러 처리
- [ ] 테스트 완료
      
## 📍관련 이슈
Fixes #17
